### PR TITLE
I'm sure this is wrong

### DIFF
--- a/jlog/jlog_config.h
+++ b/jlog/jlog_config.h
@@ -160,24 +160,24 @@ typedef unsigned long u_int32_t;
 
 /* 64-bit types */
 #ifndef HAVE_INT64_T
-#if (SIZEOF_LONG_INT == 8)
-typedef long int int64_t;
-#define HAVE_INT64_T 1
-#else
 #if (SIZEOF_LONG_LONG_INT == 8)
 typedef long long int int64_t;
 #define HAVE_INT64_T 1
 #define HAVE_LONG_LONG_INT
+#else
+#if (SIZEOF_LONG_INT == 8)
+typedef long int int64_t;
+#define HAVE_INT64_T 1
 #endif
 #endif
 #endif
 #ifndef HAVE_U_INT64_T
-#if (SIZEOF_LONG_INT == 8)
-typedef unsigned long int u_int64_t;
-#define HAVE_U_INT64_T 1
-#else
 #if (SIZEOF_LONG_LONG_INT == 8)
 typedef unsigned long long int u_int64_t;
+#define HAVE_U_INT64_T 1
+#else
+#if (SIZEOF_LONG_INT == 8)
+typedef unsigned long int u_int64_t;
 #define HAVE_U_INT64_T 1
 #endif
 #endif


### PR DESCRIPTION
but it's the least invasive thing that got fq building on my 64-bit macbook air.  In case it isn't obvious, checking for the `LONG_LONG` definitions first is what did the trick.  My C-fu is weak, so please tell me there's a more reliable way to make this work on 64-bit OSX without breaking other platforms/architectures.
