### PR TITLE
Removing fq_dtrace.h in Makefile:clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,4 +167,4 @@ install:
 	$(INSTALL) -m 0444 fq.d $(DESTDIR)/usr/lib/dtrace/fq.d
 
 clean:
-	rm -f *.o *.a fqc fqd *.$(LIBEXT)
+	rm -f *.o *.a fqc fqd *.$(LIBEXT) fq_dtrace.h


### PR DESCRIPTION
If fq_dtrace.h was rsynced from e.g. Linux gmake claen && gmake failed with:
gmake
/usr/sbin/dtrace -xnolibs -64 -G -s fq_dtrace.d -o fq_dtrace.o fqd.o fqd_listener.o fqd_ccs.o fqd_dss.o fqd_config.o fqd_queue.o fqd_routemgr.o fqd_queue_mem.o fqd_queue_jlog.o fqd_http.o fqd_prog.o fqd_peer.o http_parser.o fq_client.o fq_msg.o fq_utils.o
dtrace: failed to link script fq_dtrace.d: No probe sites found for declared provider
gmake: *** [fq_dtrace.o] Error 1