### PR TITLE
Use command line param driven set of background threads to offload work from IO thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 fqd
 fqc
 fqtool
+fq_bench
 fq_dtrace.h
 fq_rcvr
 fq_sndr
@@ -18,3 +19,4 @@ ck-*/doc/Makefile
 java/classes/
 java/*.class
 java/fqclient.jar
+*~

--- a/fq.h
+++ b/fq.h
@@ -35,6 +35,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <ck_fifo.h>
+#include <ck_stack.h>
 
 #define FQ_PROTO_CMD_MODE  0xcc50cafe
 #define FQ_PROTO_DATA_MODE 0xcc50face
@@ -129,9 +131,14 @@ typedef struct fq_msg {
   uint32_t       refcnt;
   uint32_t       payload_len;
   uint64_t       arrival_time;
+  /* saves an extra allocation and lock */
+  ck_fifo_spsc_entry_t mem_queue_entry;
+  ck_stack_entry_t cleanup_stack_entry;
+  ck_stack_t     *cleanup_stack;
   unsigned char  payload[1];  /* over allocated */
 } fq_msg;
 
+extern void    fq_msg_init_free_list();
 extern fq_msg *fq_msg_alloc(const void *payload,
                             size_t payload_size);
 extern fq_msg *fq_msg_alloc_BLANK(size_t payload_size);

--- a/fq.h
+++ b/fq.h
@@ -138,14 +138,12 @@ typedef struct fq_msg {
   uint32_t       payload_len;
   uint64_t       arrival_time;
 
-  /* saves an extra allocation and lock */
-  ck_fifo_spsc_entry_t mem_queue_entry;
   ck_stack_entry_t cleanup_stack_entry;
   free_message_stack *cleanup_stack;
 
   /* define a free function as an alternative to `free()` */
   void           (*free_fn)(struct fq_msg *m);
-  unsigned char  payload[1];  /* over allocated */
+  unsigned char  payload[];  /* over allocated */
 } fq_msg;
 
 

--- a/fq_bench.c
+++ b/fq_bench.c
@@ -21,8 +21,8 @@
  * IN THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
@@ -65,6 +65,7 @@ static void usage(const char *prog) {
   printf("\t-u <user>\tuser name\n");
   printf("\t-P <password>\tpassword\n");
   printf("\t-t <type>\t'disk' or 'mem' for type of queue to test\n");
+  printf("\t-q <queue>\tname of queue to test (default: benchmark_queue)\n");
   printf("\t-c <count>\tnumber of messages to bench with\n");
   printf("\t-s <size>\tsize of each message\n");
 }
@@ -72,15 +73,17 @@ static void usage(const char *prog) {
 static char *host = "localhost";
 static int port = 8765;
 static char *user = "user";
+static char *exchange = "maryland";
 static char *pass = "pass";
 static char *type = "mem";
+static char *queue_name = "benchmark_queue";
 static int count = 100000;
 static int size = 100;
 
 static void parse_cli(int argc, char **argv) {
   int c;
   const char *debug = getenv("FQ_DEBUG");
-  while((c = getopt(argc, argv, "Hh:p:u:P:t:c:s:")) != EOF) {
+  while((c = getopt(argc, argv, "Hh:p:u:P:t:q:e:c:s:")) != EOF) {
     switch(c) {
       case 'H':
         usage(argv[0]);
@@ -99,6 +102,12 @@ static void parse_cli(int argc, char **argv) {
         break;
       case 't':
         type = strdup(optarg);
+        break;
+      case 'q':
+        queue_name = strdup(optarg);
+        break;
+      case 'e':
+        exchange = strdup(optarg);
         break;
       case 'c':
         count = atoi(optarg);
@@ -132,7 +141,7 @@ int main(int argc, char **argv) {
 
   parse_cli(argc, argv);
 
-  sprintf(queue, "%s/%s/%s:public,drop,backlog=10000000,permanent", user, "benchmark_queue", type);
+  sprintf(queue, "%s/%s/%s:public,drop,backlog=10000000,permanent", user, queue_name, type);
 
   printf("using queue -> %s\n", queue); 
 
@@ -152,7 +161,7 @@ int main(int argc, char **argv) {
   while(i < count || fq_client_data_backlog(c) > 0) {
     if(i < count) {
       m->arrival_time = fq_gethrtime();
-      fq_msg_exchange(m, "maryland", 8);
+      fq_msg_exchange(m, exchange, strlen(exchange));
       fq_msg_route(m, "test.bench.foo", 14);
       fq_msg_id(m, NULL);
       fq_client_publish(c, m);

--- a/fq_bench.c
+++ b/fq_bench.c
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
 
   parse_cli(argc, argv);
 
-  sprintf(queue, "%s/%s/%s:public,drop,backlog=10000000,permanent", user, queue_name, type);
+  sprintf(queue, "%s/%s/%s:public,drop,backlog=10000,permanent", user, queue_name, type);
 
   printf("using queue -> %s\n", queue); 
 
@@ -157,12 +157,13 @@ int main(int argc, char **argv) {
   f = s;
 
   m = fq_msg_alloc_BLANK(size);
+  memset(m->payload, 'X', size);
+  fq_msg_exchange(m, exchange, strlen(exchange));
+  fq_msg_route(m, "test.bench.foo", 14);
 
   while(i < count || fq_client_data_backlog(c) > 0) {
     if(i < count) {
       m->arrival_time = fq_gethrtime();
-      fq_msg_exchange(m, exchange, strlen(exchange));
-      fq_msg_route(m, "test.bench.foo", 14);
       fq_msg_id(m, NULL);
       fq_client_publish(c, m);
       cnt++;

--- a/fq_client.c
+++ b/fq_client.c
@@ -564,6 +564,7 @@ fq_data_worker_loop(fq_conn_s *conn_s) {
     }
   }
 finish:
+  fq_clear_message_cleanup_stack();
   if(ctx) fq_buffered_msg_reader_free(ctx);
 #ifdef DEBUG
   fq_debug(FQ_DEBUG_CONN, "cmd_fd -> %d, stop -> %d\n", conn_s->cmd_fd, conn_s->stop);
@@ -878,7 +879,6 @@ fq_client_init(fq_client *conn_ptr, uint32_t peermode,
   conn_s->peermode = peermode;
   conn_s->errorlog = logger;
   conn_s->thrcnt = 1;
-  fq_msg_init_free_list();
   return 0;
 }
 

--- a/fq_client.c
+++ b/fq_client.c
@@ -878,6 +878,7 @@ fq_client_init(fq_client *conn_ptr, uint32_t peermode,
   conn_s->peermode = peermode;
   conn_s->errorlog = logger;
   conn_s->thrcnt = 1;
+  fq_msg_init_free_list();
   return 0;
 }
 

--- a/fq_msg.c
+++ b/fq_msg.c
@@ -80,7 +80,7 @@ again:
 }
 
 static inline fq_msg*
-msg_allocate(const size_t s, bool zero) 
+msg_allocate(const size_t s) 
 {
   fq_msg *m = calloc(1, offsetof(fq_msg, payload) + s);
   if(!m) return NULL;
@@ -100,7 +100,7 @@ msg_free(fq_msg *m)
 
 fq_msg *
 fq_msg_alloc(const void *data, size_t s) {
-  fq_msg *m = msg_allocate(s, false);
+  fq_msg *m = msg_allocate(s);
   if (unlikely(m == NULL)) {
     return NULL;
   }
@@ -115,7 +115,7 @@ fq_msg_alloc(const void *data, size_t s) {
 
 fq_msg *
 fq_msg_alloc_BLANK(size_t s) {
-  fq_msg *m = msg_allocate(s, true);
+  fq_msg *m = msg_allocate(s);
   if (unlikely(m == NULL)) {
     return NULL;
   }

--- a/fq_msg.c
+++ b/fq_msg.c
@@ -79,22 +79,16 @@ again:
   goto again;
 }
 
-static fq_msg*
+static inline fq_msg*
 msg_allocate(const size_t s, bool zero) 
 {
-  fq_msg *m = NULL;
-  /* always allocate to the next pow2 for each message so it fits neatly in a bucket */
-  m = malloc(offsetof(fq_msg, payload) + s);
+  fq_msg *m = calloc(1, offsetof(fq_msg, payload) + s);
   if(!m) return NULL;
-  memset(m, 0, offsetof(fq_msg, payload));
   m->payload_len = s;
-  if (zero) {
-    memset(m->payload, 0, s);
-  }
   return m;
 }
 
-static void
+static inline void
 msg_free(fq_msg *m)
 {
   if (m->free_fn != NULL) {

--- a/fq_msg.c
+++ b/fq_msg.c
@@ -21,14 +21,76 @@
  * IN THE SOFTWARE.
  */
 
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include "fq.h"
 #include "ck_pr.h"
+#include "ck_malloc.h"
+#include "ck_hs.h"
+#include "ck_fifo.h"
 
 #define MSG_ALIGN sizeof(void *)
+#define MAX_FREE_LIST_SIZE 1000000
+
+static bool msg_free_list_inited = false;
+static ck_hs_t msg_free_lists;
+static pthread_mutex_t msg_free_list_mutex;
+
+struct free_list {
+  uint32_t size_bound;
+  uint32_t fifo_len;
+  ck_fifo_spsc_t fifo;
+};
+
+static inline unsigned long 
+msg_free_list_hash_cb(const void* a, unsigned long seed) 
+{
+  return (unsigned long) a;
+}
+
+static inline  bool
+msg_free_list_compare_cb(const void *c1, const void *c2) 
+{
+  const struct free_list *a = c1;
+  const struct free_list *b = c2;
+
+  return a->size_bound == b->size_bound;
+}
+
+static void *
+malloc_wrapper(size_t s) {
+  return malloc(s);
+}
+
+static void *
+realloc_wrapper(void *o, size_t s, size_t x, bool b) {
+  return realloc(o, s);
+}
+
+static void
+free_wrapper(void *s, size_t size, bool b) {
+  free(s);
+}
+
+struct ck_malloc hs_allocator = {
+  .malloc = &malloc_wrapper,
+  .realloc = &realloc_wrapper,
+  .free = &free_wrapper
+};
+
+void 
+fq_msg_init_free_list()
+{
+  if (!msg_free_list_inited) {
+    ck_hs_init(&msg_free_lists, CK_HS_MODE_OBJECT | CK_HS_MODE_SPMC, msg_free_list_hash_cb,
+             msg_free_list_compare_cb, &hs_allocator, 24, 23409238432L); /* randomly entered */
+    pthread_mutex_init(&msg_free_list_mutex, NULL);
+    msg_free_list_inited = true;
+  }
+}
 
 static fq_msgid local_msgid = {
   .id = {
@@ -40,6 +102,23 @@ static fq_msgid local_msgid = {
     }
   }
 };
+
+static inline uint32_t 
+next_power_of_2(uint32_t num)
+{
+  int count = 0;
+
+  /* already a power of 2 */
+  if (num != 0 && (num & (num-1)) == 0) {
+    return num;
+  }
+
+  while (num != 0) {
+    num >>= 1;
+    count++;
+  }
+  return (1 << count);
+}
 
 static void
 pull_next_local_msgid(fq_msgid *msgid) {
@@ -72,34 +151,62 @@ again:
   goto again;
 }
 
-fq_msg *
-fq_msg_alloc(const void *data, size_t s) {
-  fq_msg *m;
-  m = malloc(offsetof(fq_msg, payload) + ((s | (MSG_ALIGN-1))+1));
+/**
+ * Will consult a hashset of fifos to grab the fifo that is next power of 2 larger
+ * than the requested incoming size.  If we find one and that fifo has items in it, 
+ * we blank out and return that fq_msg pointer.  If not we fall back on malloc.
+ * 
+ * The returned message payload_len is guaranteed to be at least `s` or larger.
+ */
+static fq_msg*
+msg_allocate(const size_t s, bool zero) 
+{
+  fq_msg *m = NULL;
+  uint32_t npot = next_power_of_2(s);
+  /* always allocate to the next pow2 for each message so it fits neatly in a bucket */
+  m = malloc(offsetof(fq_msg, payload) + npot);
   if(!m) return NULL;
   memset(m, 0, offsetof(fq_msg, payload));
   m->payload_len = s;
+  if (zero) {
+    memset(m->payload, 0, npot);
+  }
+  return m;
+}
+
+static void
+msg_free(fq_msg *m)
+{
+  if (m->cleanup_stack != NULL) {
+    ck_stack_push_mpmc(m->cleanup_stack, &m->cleanup_stack_entry);
+  } else {
+    free(m);
+  }
+}
+
+fq_msg *
+fq_msg_alloc(const void *data, size_t s) {
+  fq_msg *m = msg_allocate(s, false);
   if(s) memcpy(m->payload, data, s);
 #ifdef DEBUG
   fq_debug(FQ_DEBUG_MSG, "msg(%p) -> alloc\n", (void *)m);
 #endif
-  m->arrival_time = fq_gethrtime();
+  //m->arrival_time = fq_gethrtime();
   m->refcnt = 1;
   return m;
 }
+
 fq_msg *
 fq_msg_alloc_BLANK(size_t s) {
-  fq_msg *m;
-  m = calloc(offsetof(fq_msg, payload) + ((s | (MSG_ALIGN-1))+1), 1);
-  if(!m) return NULL;
-  m->payload_len = s;
+  fq_msg *m = msg_allocate(s, true);
 #ifdef DEBUG
   fq_debug(FQ_DEBUG_MSG, "msg(%p) -> alloc\n", (void *)m);
 #endif
-  m->arrival_time = fq_gethrtime();
+  //m->arrival_time = fq_gethrtime();
   m->refcnt = 1;
   return m;
 }
+
 void
 fq_msg_ref(fq_msg *msg) {
   ck_pr_inc_uint(&msg->refcnt);
@@ -113,7 +220,7 @@ fq_msg_deref(fq_msg *msg) {
 #ifdef DEBUG
     fq_debug(FQ_DEBUG_MSG, "msg(%p) -> free\n", (void *)msg);
 #endif
-    free(msg);
+    msg_free(msg);
   }
 }
 void

--- a/fq_msg.c
+++ b/fq_msg.c
@@ -82,7 +82,7 @@ again:
 static inline fq_msg*
 msg_allocate(const size_t s) 
 {
-  fq_msg *m = calloc(1, offsetof(fq_msg, payload) + s);
+  fq_msg *m = calloc(1, sizeof(fq_msg) + s);
   if(!m) return NULL;
   m->payload_len = s;
   return m;

--- a/fq_utils.c
+++ b/fq_utils.c
@@ -52,6 +52,7 @@ void
 fq_init_free_message_stack(free_message_stack *stack, const size_t max_free_count)
 {
   ck_stack_init(&stack->stack);
+  stack->size = 0;
   stack->max_size = max_free_count;
 }
 

--- a/fq_utils.c
+++ b/fq_utils.c
@@ -343,7 +343,7 @@ fq_buffered_msg_read(buffered_msg_reader *f,
       f->copy->refcnt = 1;
       f->copy->payload_len = CAPPED(f->copy->payload_len);
       fq_debug(FQ_DEBUG_MSG, "message read... injecting\n");
-      //f->copy->arrival_time = fq_gethrtime();
+      f->copy->arrival_time = fq_gethrtime();
       f_msg_handler(closure, f->copy);
       f->copy = NULL;
       memset(&f->msg, 0, sizeof(f->msg));

--- a/fqd_dss.c
+++ b/fqd_dss.c
@@ -99,8 +99,8 @@ fqd_worker_thread(void *arg)
         /* the copy will be freed as normal so eliminate cleanup_stack pointer */
         copy->cleanup_stack = NULL;
         /* we are done with the incoming message, drop it on it's cleanup stack */
+        fqd_inject_message(m->client, copy);
         fq_msg_deref(m->msg);
-        fqd_inject_message(m->client, m->msg);
         free(m);
       }
     }

--- a/fqd_listener.c
+++ b/fqd_listener.c
@@ -158,6 +158,8 @@ fqd_listener(const char *host, unsigned short port) {
   if(bind(fd, (struct sockaddr *)&laddr, sizeof(laddr)) < 0) return -1;
   if(listen(fd, 16) < 0) return -1;
 
+  fq_msg_init_free_list();
+
   while(1) {
     pthread_t client_task;
     pthread_attr_t client_task_attr;

--- a/fqd_listener.c
+++ b/fqd_listener.c
@@ -158,8 +158,6 @@ fqd_listener(const char *host, unsigned short port) {
   if(bind(fd, (struct sockaddr *)&laddr, sizeof(laddr)) < 0) return -1;
   if(listen(fd, 16) < 0) return -1;
 
-  fq_msg_init_free_list();
-
   while(1) {
     pthread_t client_task;
     pthread_attr_t client_task_attr;

--- a/fqd_listener.c
+++ b/fqd_listener.c
@@ -133,7 +133,9 @@ conn_handler(void *vc) {
     DTRACE_PACK_ANON_CLIENT(&dc, client);
     FQ_CLIENT_DISCONNECT(&dc, ntohl(cmd));
   }
-  free(client);
+
+  /* let deref do it */
+  //free(client);
   return NULL;
 }
 

--- a/fqd_private.h
+++ b/fqd_private.h
@@ -24,6 +24,8 @@
 #ifndef FQD_PRIVATE_H
 #define FQD_PRIVATE_H
 
+#include "fq.h"
+
 #define MAX_QUEUE_CLIENTS 16
 
 struct fqd_route_stats {
@@ -83,5 +85,8 @@ extern int
   for_each_route_rule_do(struct fqd_route_rules *set,
                          int (*f)(struct fqd_route_rule *, int, void *),
                          void *closure);
+
+void fqd_start_worker_threads(int thread_count);
+void fqd_stop_worker_threads();
 
 #endif

--- a/fqd_queue.c
+++ b/fqd_queue.c
@@ -157,6 +157,7 @@ fqd_queue_enqueue(fqd_queue *q, fq_msg *m, int *dropped) {
   }
   q->impl->enqueue(q->impl_data, m);
 }
+
 fq_msg *
 fqd_queue_dequeue(fqd_queue *q) {
   fq_msg *msg = q->impl->dequeue(q->impl_data);

--- a/fqd_queue_jlog.c
+++ b/fqd_queue_jlog.c
@@ -282,15 +282,19 @@ static fqd_queue_impl_data queue_jlog_setup(fq_rk *qname, uint32_t *count) {
   fqd_config_construct_queue_path(qpath, sizeof(qpath), qname);
   d->qpath = strdup(qpath);
   d->writer = jlog_new(d->qpath);
+  jlog_ctx_set_use_compression(d->writer, 1);
+
   if(jlog_ctx_open_writer(d->writer) != 0) {
     jlog_ctx_close(d->writer);
     d->writer = jlog_new(d->qpath);
+    jlog_ctx_set_use_compression(d->writer, 1);
     if(jlog_ctx_init(d->writer) != 0) {
       fq_debug(FQ_DEBUG_IO, "jlog init: %s\n", jlog_ctx_err_string(d->writer));
       goto bail;
     }
     jlog_ctx_close(d->writer);
     d->writer = jlog_new(d->qpath);
+    jlog_ctx_set_use_compression(d->writer, 1);
     if(jlog_ctx_open_writer(d->writer) != 0) {
       fq_debug(FQ_DEBUG_IO, "jlog writer: %s\n", jlog_ctx_err_string(d->writer));
       goto bail;
@@ -301,6 +305,7 @@ static fqd_queue_impl_data queue_jlog_setup(fq_rk *qname, uint32_t *count) {
   jlog_ctx_alter_journal_size(d->writer, 128 * 1024 * 1024);
 
   d->reader = jlog_new(d->qpath);
+  jlog_ctx_set_use_compression(d->reader, 1);
   if(jlog_get_checkpoint(d->reader, "fq", &chkpt) != 0) {
     if(jlog_ctx_add_subscriber(d->reader, "fq", JLOG_BEGIN) != 0) {
       fq_debug(FQ_DEBUG_IO, "jlog add sub: %s\n", jlog_ctx_err_string(d->reader));

--- a/fqd_queue_jlog.c
+++ b/fqd_queue_jlog.c
@@ -282,11 +282,16 @@ static fqd_queue_impl_data queue_jlog_setup(fq_rk *qname, uint32_t *count) {
   fqd_config_construct_queue_path(qpath, sizeof(qpath), qname);
   d->qpath = strdup(qpath);
   d->writer = jlog_new(d->qpath);
+  
+  jlog_ctx_set_pre_commit_buffer_size(d->writer, 1024 * 1024);
+  jlog_ctx_set_multi_process(d->writer, 0);
   jlog_ctx_set_use_compression(d->writer, 1);
 
   if(jlog_ctx_open_writer(d->writer) != 0) {
     jlog_ctx_close(d->writer);
     d->writer = jlog_new(d->qpath);
+    jlog_ctx_set_pre_commit_buffer_size(d->writer, 1024 * 1024);
+    jlog_ctx_set_multi_process(d->writer, 0);
     jlog_ctx_set_use_compression(d->writer, 1);
     if(jlog_ctx_init(d->writer) != 0) {
       fq_debug(FQ_DEBUG_IO, "jlog init: %s\n", jlog_ctx_err_string(d->writer));
@@ -294,6 +299,8 @@ static fqd_queue_impl_data queue_jlog_setup(fq_rk *qname, uint32_t *count) {
     }
     jlog_ctx_close(d->writer);
     d->writer = jlog_new(d->qpath);
+    jlog_ctx_set_pre_commit_buffer_size(d->writer, 1024 * 1024);
+    jlog_ctx_set_multi_process(d->writer, 0);
     jlog_ctx_set_use_compression(d->writer, 1);
     if(jlog_ctx_open_writer(d->writer) != 0) {
       fq_debug(FQ_DEBUG_IO, "jlog writer: %s\n", jlog_ctx_err_string(d->writer));
@@ -305,7 +312,6 @@ static fqd_queue_impl_data queue_jlog_setup(fq_rk *qname, uint32_t *count) {
   jlog_ctx_alter_journal_size(d->writer, 128 * 1024 * 1024);
 
   d->reader = jlog_new(d->qpath);
-  jlog_ctx_set_use_compression(d->reader, 1);
   if(jlog_get_checkpoint(d->reader, "fq", &chkpt) != 0) {
     if(jlog_ctx_add_subscriber(d->reader, "fq", JLOG_BEGIN) != 0) {
       fq_debug(FQ_DEBUG_IO, "jlog add sub: %s\n", jlog_ctx_err_string(d->reader));

--- a/fqd_queue_jlog.c
+++ b/fqd_queue_jlog.c
@@ -296,6 +296,10 @@ static fqd_queue_impl_data queue_jlog_setup(fq_rk *qname, uint32_t *count) {
       goto bail;
     }
   }
+
+  /* 128MB journal chunks */
+  jlog_ctx_alter_journal_size(d->writer, 128 * 1024 * 1024);
+
   d->reader = jlog_new(d->qpath);
   if(jlog_get_checkpoint(d->reader, "fq", &chkpt) != 0) {
     if(jlog_ctx_add_subscriber(d->reader, "fq", JLOG_BEGIN) != 0) {

--- a/fqd_queue_mem.c
+++ b/fqd_queue_mem.c
@@ -27,37 +27,37 @@
 
 struct queue_mem {
   uint32_t              qlen;
-  ck_fifo_mpmc_t        q;
-  ck_fifo_mpmc_entry_t *qhead;
+  ck_fifo_spsc_t        q;
+  ck_fifo_spsc_entry_t *qhead;
 };
 
 static void queue_mem_enqueue(fqd_queue_impl_data f, fq_msg *m) {
   struct queue_mem *d = (struct queue_mem *)f;
-  ck_fifo_mpmc_entry_t *fifo_entry;
-  fifo_entry = malloc(sizeof(ck_fifo_mpmc_entry_t));
+  ck_fifo_spsc_enqueue_lock(&d->q);
+  ck_fifo_spsc_entry_t *fifo_entry = &m->mem_queue_entry;
   fq_msg_ref(m);
-  ck_fifo_mpmc_enqueue(&d->q, fifo_entry, m);
+  ck_fifo_spsc_enqueue(&d->q, fifo_entry, m);
+  ck_fifo_spsc_enqueue_unlock(&d->q);
   ck_pr_inc_uint(&d->qlen);
 }
 static fq_msg *queue_mem_dequeue(fqd_queue_impl_data f) {
   struct queue_mem *d = (struct queue_mem *)f;
-  ck_fifo_mpmc_entry_t *garbage;
-  fq_msg *m;
-  if(ck_fifo_mpmc_dequeue(&d->q, &m, &garbage) == true) {
+  fq_msg *m = NULL;
+  ck_fifo_spsc_dequeue_lock(&d->q);
+  if(ck_fifo_spsc_dequeue(&d->q, &m) == true) {
+    ck_fifo_spsc_dequeue_unlock(&d->q);
     ck_pr_dec_uint(&d->qlen);
-    /* We can free this only because this fifo is used as a
-     * multi-producer and *single* consumer */
-    if(garbage != d->qhead) free(garbage);
     return m;
   }
+  ck_fifo_spsc_dequeue_unlock(&d->q);
   return NULL;
 }
 static fqd_queue_impl_data queue_mem_setup(fq_rk *qname, uint32_t *count) {
   struct queue_mem *d;
   d = calloc(1, sizeof(*d));
-  d->qhead = malloc(sizeof(ck_fifo_mpmc_entry_t));
+  d->qhead = malloc(sizeof(ck_fifo_spsc_entry_t));
   *count = 0;
-  ck_fifo_mpmc_init(&d->q, d->qhead);
+  ck_fifo_spsc_init(&d->q, d->qhead);
   (void)qname;
   return d;
 }

--- a/fqd_routemgr.c
+++ b/fqd_routemgr.c
@@ -58,14 +58,14 @@ apply_compiled_program_node(rulenode_t *p, fq_msg *m) {
 static bool
 apply_compiled_program(struct fqd_route_rule *r, fq_msg *m) {
   bool rv;
-  //  hrtime_t start, delta, rpl;
+  hrtime_t start, delta, rpl;
   ck_pr_add_64(&r->stats->invocations, 1);
-  //start = fq_gethrtime();
+  start = fq_gethrtime();
   rv = apply_compiled_program_node(r->compiled_program, m);
-  //delta = fq_gethrtime() - start;
+  delta = fq_gethrtime() - start;
   /* simple exp smoothing (alpha = 127/128) */
-  //rpl = ((r->stats->avg_ns * 127)>>7) + (delta>>7);
-  //r->stats->avg_ns = rpl;
+  rpl = ((r->stats->avg_ns * 127)>>7) + (delta>>7);
+  r->stats->avg_ns = rpl;
   return rv;
 }
 struct queue_target {

--- a/fqd_routemgr.c
+++ b/fqd_routemgr.c
@@ -58,14 +58,14 @@ apply_compiled_program_node(rulenode_t *p, fq_msg *m) {
 static bool
 apply_compiled_program(struct fqd_route_rule *r, fq_msg *m) {
   bool rv;
-  hrtime_t start, delta, rpl;
+  //  hrtime_t start, delta, rpl;
   ck_pr_add_64(&r->stats->invocations, 1);
-  start = fq_gethrtime();
+  //start = fq_gethrtime();
   rv = apply_compiled_program_node(r->compiled_program, m);
-  delta = fq_gethrtime() - start;
+  //delta = fq_gethrtime() - start;
   /* simple exp smoothing (alpha = 127/128) */
-  rpl = ((r->stats->avg_ns * 127)>>7) + (delta>>7);
-  r->stats->avg_ns = rpl;
+  //rpl = ((r->stats->avg_ns * 127)>>7) + (delta>>7);
+  //r->stats->avg_ns = rpl;
   return rv;
 }
 struct queue_target {


### PR DESCRIPTION
We can offload allocations to copy the message as well as route checking from the IO thread to a set of worker threads to actually perform that work.  This allows keeping a higher throughput of reads and writes.