### PR TITLE
Fix build issue when libbcd is absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,13 @@ FQC_OBJ=fqc.o $(CLIENT_OBJ)
 FQD_SAMPLE_OBJ=fqd_dyn_sample.lo
 FQD_DTRACE_OBJ=
 
+skip_bcd=$(NO_BCD)
+ifdef skip_bcd
+FQDLIBS=-ljlog -lsqlite3
+EXTRA_CFLAGS+=-DNO_BCD
+else
 FQDLIBS=-ljlog -lsqlite3 -lbcd
+endif
 LIBS+=-lck
 
 SHLDFLAGS=

--- a/README.md
+++ b/README.md
@@ -187,6 +187,26 @@ Example:
 curl -X POST -H "X-Fq-User: user" -H 'X-Fq-Route: bla' -H 'X-Fq-Exchange: test' localhost:8765/submit --data "TEST"
 ```
 
+## Building
+
+Requirements:
+* C compiler
+* GNU make
+* sqlite3
+* [jlog](https://github.com/omniti-labs/jlog)
+* [libbcd](https://github.com/backtrace-labs/bcd) (optional, for crash tracing)
+
+Generally:
+```
+make
+make install
+```
+
+To build without libbcd support:
+```
+NO_BCD=1 make
+```
+
 ## Debugging
 
 FQ can be run in debug mode from the command line.

--- a/lua/generatelua.sh
+++ b/lua/generatelua.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit   # Exit script on first error.
 set -o nounset   # Treat references to unset variables as errors.


### PR DESCRIPTION
Compilation could be suppressed but linking was unconditional. Provide
Makefile suppression via environment variable.

Improve portability by not assuming the path to bash in the Lua code
generation script.