### PR TITLE
CIRC-6524 - Host Resolution Race

### DIFF
--- a/fq_client.c
+++ b/fq_client.c
@@ -257,7 +257,6 @@ fq_resolve_endpoint(fq_conn_s *conn_s) {
       for (struct addrinfo *rp = result; rp; rp = rp->ai_next) {
         if (rp->ai_addr) {
           conn_s->remote.sin_addr = ((struct sockaddr_in*)rp->ai_addr)->sin_addr;
-          conn_s->last_resolve = fq_gethrtime();
           break;
         }
       }


### PR DESCRIPTION
- Proper race free host resolution
- For the fall back to `gethostname`, use a mutex, not
  perfect but will be better nonetheless

https://circonus.atlassian.net/browse/CIRC-6524
