### PR TITLE
feat(ci/container): Statically linked fqd container

### DIFF
--- a/.github/workflows/build-push-container-image.yaml
+++ b/.github/workflows/build-push-container-image.yaml
@@ -1,0 +1,37 @@
+name: Build and Push Image
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  # TODO: change this to the actual registry
+  IMAGE_NAME: "us-central1-docker.pkg.dev/circonus.com/circonus/fq-images/fqd"
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: latest ${{ github.ref_name }} ${{ github.sha }} 
+        containerfiles: |
+          ./Dockerfile
+
+    - name: Push To registry
+      id: push-to-registry
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:${{ github.ref_name }} ${{ env.IMAGE_NAME }}:${{ github.sha }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/Circonus.repo
+++ b/Circonus.repo
@@ -1,0 +1,7 @@
+[Circonus]
+name=Circonus CentOS 7 Pilot repo
+baseurl=https://updates.circonus.net/centos/7/x86_64/
+enabled=1
+fastestmirror_enabled=0
+gpgcheck=1
+metadata_expire=1m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM centos:centos7.9.2009 AS centos
+
+WORKDIR /src/fq
+COPY . ./
+
+RUN yum -y install gcc make
+
+RUN yum -y install sqlite
+COPY Circonus.repo /etc/yum.repos.d/
+RUN rpm --import https://keybase.io/circonuspkg/pgp_keys.asc?fingerprint=14ff6826503494d85e62d2f22dd15eba6d4fa648
+RUN yum -y install circonus-platform-library-bcd circonus-platform-library-jlog circonus-platform-library-liblz4 circonus-platform-library-uuid circonus-platform-runtime-luajit
+
+RUN LDFLAGS="-static -static-libgcc -static-libstdc++" make
+
+RUN useradd -u 65534 nobody
+
+FROM scratch
+WORKDIR /
+COPY --from=centos /etc/passwd /etc/passwd
+COPY --from=centos /src/fq/fqd /fqd
+USER nobody
+ENTRYPOINT ["/fqd"]
+CMD ["-D"]


### PR DESCRIPTION

Add github actions workflow to build fqd container with Dockerfile and
upload container to GCR
Add Dockerfile with multi-stage-build and static linking to output a
minimal container
Add Circonus.repo (dependency for Dockerfile)

Add build steps to create a minimal container.

* Tags: container gcr dockerfile podman buildah